### PR TITLE
Add links to CDS Hooks library in header

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1159,6 +1159,22 @@ As a specification, CDS Hooks does not prescribe a default or required set of ho
 
 Note that each hook (e.g. `order-select`) represents something the user is doing in the CDS Client and multiple CDS Services might respond to the same hook (e.g. a "price check" service and a "prior authorization" service might both respond to `order-select`).
 
+### Library
+CDS Hooks provides a library of hooks that are available to implementers. The library is available in two forms, currently published as [published](https://cds-hooks.org/hooks/) and [development](https://build.fhir.org/ig/HL7/cds-hooks-library/) versions.
+
+* allergyintolerance-create - ([published](https://cds-hooks.org/hooks/allergyintolerance-create), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/allergyintolerance-create))
+* appointment-book - ([published](https://cds-hooks.org/hooks/appointment-book), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/appointment-book))
+* encounter-discharge - ([published](https://cds-hooks.org/hooks/encounter-discharge), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/encounter-discharge))
+* encounter-start - ([published](https://cds-hooks.org/hooks/encounter-start), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/encounter-start))
+* medication-refill - ([published](https://cds-hooks.org/hooks/medication-refill), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/medication-refill))
+* order-dispatch - ([published](https://cds-hooks.org/hooks/order-dispatch), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/order-dispatch))
+* order-select - ([published](https://cds-hooks.org/hooks/order-select), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/order-select))
+* order-sign - ([published](https://cds-hooks.org/hooks/order-sign), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/order-sign))
+* patient-view - ([published](https://cds-hooks.org/hooks/patient-view), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/patient-view))
+* problem-list-item-create - ([published](https://cds-hooks.org/hooks/problem-list-item-create), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/problem-list-item-create))
+* medication-prescribe - ([published](https://cds-hooks.org/hooks/medication-prescribe), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/medication-prescribe))
+* order-review - ([published](https://cds-hooks.org/hooks/order-review), [development](https://build.fhir.org/ig/HL7/cds-hooks-library/order-review))
+
 ### Hook context and prefetch
 
 ### What's the difference?

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -78,19 +78,7 @@ parameters:
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 menu:
   Home: index.html
-  Hook Library:
-    allergyintolerance-create (1): https://build.fhir.org/ig/HL7/cds-hooks-library/allergyintolerance-create.html
-    appointment-book (1): https://build.fhir.org/ig/HL7/cds-hooks-library/appointment-book.html
-    encounter-discharge (1): https://build.fhir.org/ig/HL7/cds-hooks-library/encounter-discharge.html
-    encounter-start (1): https://build.fhir.org/ig/HL7/cds-hooks-library/encounter-start.html
-    medication-refill (1): https://build.fhir.org/ig/HL7/cds-hooks-library/medication-refill.html
-    order-dispatch (0): https://build.fhir.org/ig/HL7/cds-hooks-library/order-dispatch.html
-    order-select (4) : https://build.fhir.org/ig/HL7/cds-hooks-library/order-select.html
-    order-sign (5): https://build.fhir.org/ig/HL7/cds-hooks-library/order-sign.html
-    patient-view (5): https://build.fhir.org/ig/HL7/cds-hooks-library/patient-view.html
-    problem-list-item-create (1): https://build.fhir.org/ig/HL7/cds-hooks-library/problem-list-item-create.html
-    medication-prescribe (deprecated): https://build.fhir.org/ig/HL7/cds-hooks-library/medication-prescribe.html
-    order-review (deprecated): https://build.fhir.org/ig/HL7/cds-hooks-library/order-review.html
+  Hook Library: index.html#library
 
 # ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
 # │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │


### PR DESCRIPTION
I've thought a bit about how can we add both development and preview links to the CDS Hooks and came up with this solution - create a menu within the main spec that contains both sets of links. This is similar to how the FHIR spec makes different versions of a resource available with the "Page versions: R5 [R4B](http://hl7.org/fhir/R4B/patient.html) [R4](http://hl7.org/fhir/R4/patient.html) [R3](http://hl7.org/fhir/STU3/patient.html) [R2](http://hl7.org/fhir/DSTU2/patient.html)" links.

Here's how it looks like for CDS Hooks:

[Screencast from 2024-10-02 14-48-13.webm](https://github.com/user-attachments/assets/10fa7978-0e53-4cee-863e-32857ba0145d)
