### PR TITLE
mess with linking to library

### DIFF
--- a/input/includes/relative-link.html
+++ b/input/includes/relative-link.html
@@ -4,7 +4,9 @@
 {% elsif release == "draft" %}
     <a href="{{site.data.links.library-contexts.build.url}}{{include.link}}">{{include.title}}</a>
 {% elsif release == "trial-use" %}
-<a href="{{site.data.links.library-contexts.current.url}}{{include.link}}">{{include.title}}</a>
+    <a href="{{site.data.links.library-contexts.current.url}}{{include.link}}">{{include.title}}</a>
+{% elsif release == "STU2" %}
+    <a href="{{site.data.links.library-contexts.current.url}}{{include.link}}">{{include.title}}</a>
 {% else %}
-    <a href="{{site.data.links.library-contexts.relative.url}}{{include.link}}">{{include.title}}</a>
+    <a href="{{site.data.links.library-contexts.build.url}}{{include.link}}">{{include.title}}</a>
 {% endif %}

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -13,7 +13,12 @@ version: 2.0.1
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2019+
 copyrightLabel: "HL7 & Boston Children's Hospital"
-releaseLabel: STU2 # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+# 
+# ╭───────────────────────────Before changing releaseLabel──────────────────────────╮
+# │  Confirm that the releaseLabel value you are choosing is mapped to an IG guide  |
+# │  url prefix in this file: input/includes/relative-link.html                     │
+# ╰─────────────────────────────────────────────────────────────────────────────────╯
+releaseLabel: STU2 # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use 
 license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 jurisdiction: 'http://unstats.un.org/unsd/methods/m49/m49.htm#001'
 publisher:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -18,7 +18,7 @@ copyrightLabel: "HL7 & Boston Children's Hospital"
 # │  Confirm that the releaseLabel value you are choosing is mapped to an IG guide  |
 # │  url prefix in this file: input/includes/relative-link.html                     │
 # ╰─────────────────────────────────────────────────────────────────────────────────╯
-releaseLabel: STU2 # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use 
+releaseLabel: ci-build # STU2 # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use 
 license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 jurisdiction: 'http://unstats.un.org/unsd/methods/m49/m49.htm#001'
 publisher:


### PR DESCRIPTION
relative links are broken, they don't work with publisher. (Recent release label change, trigged else stmt that defauled to relative, which broke build)

To understand how these links work, look at:
* input/includes/menu.xml
* input/includes/relative-link.html
* input/data/links.yml
* sushi-config.yml