### PR TITLE
Merge right before next publication!

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -18,7 +18,7 @@ copyrightLabel: "HL7 & Boston Children's Hospital"
 # │  Confirm that the releaseLabel value you are choosing is mapped to an IG guide  |
 # │  url prefix in this file: input/includes/relative-link.html                     │
 # ╰─────────────────────────────────────────────────────────────────────────────────╯
-releaseLabel: ci-build # STU2 # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use 
+releaseLabel: STU2 # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use 
 license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 jurisdiction: 'http://unstats.un.org/unsd/methods/m49/m49.htm#001'
 publisher:


### PR DESCRIPTION
Because we're publishing both the CDS Hooks and CDS Hooks Library IGs for the first time, at the same time, we need to orchestrate the order of publication by following these steps:

## Sequence of events of publication process
1. Merge https://github.com/HL7/cds-hooks/pull/16
2. Publish CDS Hooks IG
3. Merge https://github.com/HL7/cds-hooks-library/pull/17 !
4. Publish CDS Hooks Library IG