### PR TITLE
Make `jku` parameter SHOULD

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1036,7 +1036,7 @@ Per [rfc7519](https://tools.ietf.org/html/rfc7519#section-4.1.3), the `aud` valu
 
 The CDS Client MUST make its public key, expressed as a JSON Web Key (JWK), available in a JWK Set, as defined by [rfc7517](https://tools.ietf.org/html/rfc7517). The `kid` value from the JWT header allows a CDS Service to identify the correct JWK in the JWK Set that can be used to verify the signature.
 
-The CDS Client MAY make its JWK Set available via a URL identified by the `jku` header field, as defined by [rfc7515 4.1.2](https://tools.ietf.org/html/rfc7515#section-4.1.2). If the `jku` header field is ommitted, the CDS Client and CDS Service SHALL communicate the JWK Set out-of-band.
+The CDS Client SHOULD make its JWK Set available via a URL identified by the `jku` header field, as defined by [rfc7515 4.1.2](https://tools.ietf.org/html/rfc7515#section-4.1.2) and promote security best practices of rotating public keys. If the `jku` header field is ommitted, the CDS Client and CDS Service SHALL communicate the JWK Set out-of-band.
 
 ##### JWT Signing Algorithm
 


### PR DESCRIPTION
Make `jku` parameter SHOULD [per resolution](https://jira.hl7.org/browse/FHIR-41437). Note that the resolution suggested the text `... **to** promote security best practices of rotating public keys` but I went with `... **and** promote security best practices` since just publishing the URL does not imply that keys will actually be rotated.