### PR TITLE
Align logical models with narrative and add Feedback logical model

### DIFF
--- a/FHIR-cds-hooks.xml
+++ b/FHIR-cds-hooks.xml
@@ -14,6 +14,7 @@
 <artifactPageExtension value="-mappings"/>
 <artifact id="StructureDefinition/CDSHookContext" key="StructureDefinition-CDSHookContext" name="CDS Hook Specific Context (Logical Definition)"/>
 <artifact id="StructureDefinition/CDSHooksServices" key="StructureDefinition-CDSHooksServices" name="CDSHooks Discovery Response (Logical Definition)"/>
+<artifact id="StructureDefinition/CDSHooksFeedback" key="StructureDefinition-CDSHooksFeedback" name="CDSHooks Feedback (Logical Definition)"/>
 <artifact id="StructureDefinition/CDSHooksRequest" key="StructureDefinition-CDSHooksRequest" name="CDSHooks Request (Logical Definition)"/>
 <artifact id="StructureDefinition/CDSHooksResponse" key="StructureDefinition-CDSHooksResponse" name="CDSHooks Response (Logical Definition)"/>
 <artifact id="StructureDefinition/CDSHooksElement" key="StructureDefinition-CDSHooksElement" name="CDSHooks Services Base Extensible Element"/>

--- a/FHIR-cds-hooks.xml
+++ b/FHIR-cds-hooks.xml
@@ -13,11 +13,11 @@
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>
 <artifact id="StructureDefinition/CDSHookContext" key="StructureDefinition-CDSHookContext" name="CDS Hook Specific Context (Logical Definition)"/>
+<artifact id="StructureDefinition/CDSHooksServices" key="StructureDefinition-CDSHooksServices" name="CDSHooks Discovery Response (Logical Definition)"/>
 <artifact id="StructureDefinition/CDSHooksRequest" key="StructureDefinition-CDSHooksRequest" name="CDSHooks Request (Logical Definition)"/>
 <artifact id="StructureDefinition/CDSHooksResponse" key="StructureDefinition-CDSHooksResponse" name="CDSHooks Response (Logical Definition)"/>
 <artifact id="StructureDefinition/CDSHooksElement" key="StructureDefinition-CDSHooksElement" name="CDSHooks Services Base Extensible Element"/>
 <artifact id="StructureDefinition/CDSHooksExtensions" key="StructureDefinition-CDSHooksExtensions" name="CDSHooks Services Extensions"/>
-<artifact id="StructureDefinition/CDSHooksServices" key="StructureDefinition-CDSHooksServices" name="CDSHooks Services Request (Logical Definition)"/>
 <artifact deprecated="true" key="Conformance" name="Conformance"/>
 <artifact deprecated="true" id="Hooks/appointment-book" key="Hooks-appointment-book" name="Hooks - Appointment Book"/>
 <artifact deprecated="true" id="Hooks/encounter-discharge" key="Hooks-encounter-discharge" name="Hooks - Encounter Discharge"/>

--- a/input/fsh/invariants/cds-fb-1.fsh
+++ b/input/fsh/invariants/cds-fb-1.fsh
@@ -1,0 +1,4 @@
+Invariant: cds-fb-1
+Description: "outcome must be 'accepted' or 'overridden'"
+* severity = #error
+* expression = "outcome = 'accepted' or outcome = 'overridden'"

--- a/input/fsh/invariants/cds-fb-2.fsh
+++ b/input/fsh/invariants/cds-fb-2.fsh
@@ -1,0 +1,4 @@
+Invariant: cds-fb-2
+Description: "If outcome is 'accepted', acceptedSuggestions SHALL be provided"
+* severity = #error
+* expression = "(outcome = 'accepted') implies acceptedSuggestions.exists()"

--- a/input/fsh/invariants/cds-fb-3.fsh
+++ b/input/fsh/invariants/cds-fb-3.fsh
@@ -1,0 +1,4 @@
+Invariant: cds-fb-3
+Description: "An overrideReason must contain a reason, a userComment, or both"
+* severity = #error
+* expression = "reason.exists() or userComment.exists()"

--- a/input/fsh/invariants/cds-resp-7.fsh
+++ b/input/fsh/invariants/cds-resp-7.fsh
@@ -1,0 +1,4 @@
+Invariant: cds-resp-7
+Description: "actionSelectionBehavior must be 'all', 'any', or 'at-most-one'"
+* severity = #error
+* expression = "actionSelectionBehavior.empty() or actionSelectionBehavior = 'all' or actionSelectionBehavior = 'any' or actionSelectionBehavior = 'at-most-one'"

--- a/input/fsh/logicals/CDSHooksFeedback.fsh
+++ b/input/fsh/logicals/CDSHooksFeedback.fsh
@@ -1,0 +1,26 @@
+Logical: CDSHooksFeedback
+Parent: CDSHooksElement
+Id: CDSHooksFeedback
+Title: "CDSHooks Feedback (Logical Definition)"
+Description: "This structure is defined to allow the FHIR Validator to validate a CDSHooks Feedback request body."
+* ^status = #draft
+* ^experimental = true
+* . ^short = "The request body for the CDS Hooks feedback endpoint"
+* . ^definition = "Feedback that a CDS Client POSTs to a CDS Service's feedback endpoint. The request body is an object containing an array of one or more Feedback entries reporting end-user interaction with cards previously returned by the CDS Service."
+* feedback 0..* http://hl7.org/fhir/tools/StructureDefinition/CDSHooksElement "Array of Feedback entries" "An array of Feedback entries reporting end-user interaction with cards previously returned by the CDS Service."
+* feedback obeys cds-fb-1 and cds-fb-2
+* feedback ^extension.url = "http://hl7.org/fhir/tools/StructureDefinition/json-empty-behavior"
+* feedback ^extension.valueCode = #present
+* feedback.card 1..1 uuid "Identifier of the card the user acted on" "The card.uuid from the CDS Hooks response. Uniquely identifies the card."
+* feedback.card ^extension[+].url = "http://hl7.org/fhir/tools/StructureDefinition/implied-string-prefix"
+* feedback.card ^extension[=].valueString = "urn:uuid:"
+* feedback.outcome 1..1 code "accepted | overridden" "A value of accepted or overridden."
+* feedback.acceptedSuggestions 0..* http://hl7.org/fhir/tools/StructureDefinition/CDSHooksElement "Suggestions accepted by the user" "An array of objects identifying one or more of the user's AcceptedSuggestions. Required for 'accepted' outcomes."
+* feedback.acceptedSuggestions.id 1..1 uuid "Identifier of the accepted suggestion" "The card.suggestion.uuid from the CDS Hooks response. Uniquely identifies the suggestion that was accepted."
+* feedback.acceptedSuggestions.id ^extension[+].url = "http://hl7.org/fhir/tools/StructureDefinition/implied-string-prefix"
+* feedback.acceptedSuggestions.id ^extension[=].valueString = "urn:uuid:"
+* feedback.overrideReason 0..1 http://hl7.org/fhir/tools/StructureDefinition/CDSHooksElement "Reason the user overrode the card" "Captures the override reason as a Coding as well as any free-text comment entered by the user."
+* feedback.overrideReason obeys cds-fb-3
+* feedback.overrideReason.reason 0..1 Coding "The override reason selected by the end user" "The Coding object representing the override reason selected by the end user. Required if the user selected an override reason from the list of reasons provided in the Card (instead of only leaving a userComment)."
+* feedback.overrideReason.userComment 0..1 string "Free text user comment" "Free text the clinician provided to further explain why the card was rejected."
+* feedback.outcomeTimestamp 1..1 instant "When the user took action on the card" "ISO8601 representation of the date and time in Coordinated Universal Time (UTC) when action was taken on the card, as profiled in section 5.6 of RFC3339 (e.g. 1985-04-12T23:20:50.52Z)."

--- a/input/fsh/logicals/CDSHooksRequest.fsh
+++ b/input/fsh/logicals/CDSHooksRequest.fsh
@@ -8,7 +8,7 @@ Description: "This structure is defined to allow the FHIR Validator to validate 
 * obeys cds-r-1
 * . ^short = "A request for decision support"
 * . ^definition = "The data structure that used when invoking a CDS Hook service"
-* hook 1..1 code "The hook that triggered this CDS Service call" "The hook that triggered this CDS Service call"
+* hook 1..1 string "The hook that triggered this CDS Service call" "The hook that triggered this CDS Service call"
 * hookInstance 1..1 uuid "A UUID for this particular hook call" "While working in the CDS Client, a user can perform multiple actions in series or in parallel. For example, a clinician might prescribe two drugs in a row; each prescription action would be assigned a unique hookInstance. This allows a CDS Service to uniquely identify each hook invocation"
 * hookInstance ^extension[0].url = "http://hl7.org/fhir/tools/StructureDefinition/implied-string-prefix"
 * hookInstance ^extension[=].valueString = "urn:uuid:"

--- a/input/fsh/logicals/CDSHooksResponse.fsh
+++ b/input/fsh/logicals/CDSHooksResponse.fsh
@@ -47,7 +47,7 @@ Description: "This structure is defined to allow the FHIR Validator to validate 
 * cards.suggestions.actions.description ^condition[0] = "cds-resp-5"
 * cards.suggestions.actions.resource 0..1 Resource "FHIR resource to create/update" "When the type attribute is create, the resource attribute SHALL contain a new FHIR resource to be created. For update, this holds the updated resource in its entirety and not just the changed fields."
 * cards.suggestions.actions.resource ^comment = "Use of this field to communicate a string of a FHIR id for delete suggestions is DEPRECATED and resourceId SHOULD be used instead."
-* cards.suggestions.actions.resourceId 0..1 url "A relative reference to the relevant resource." "A relative reference to the relevant resource. SHOULD be provided when the type attribute is delete."
+* cards.suggestions.actions.resourceId 0..1 string "A relative reference to the relevant resource." "A relative reference to the relevant resource. SHOULD be provided when the type attribute is delete."
 * cards.suggestions.actions.resourceId ^comment = ""
 * cards.suggestions.actionSelectionBehavior 0..1 code "all | any | at-most-one (default: all)" "Indicates whether the end user may select any, none, or only a single action from those included in the suggestion. Allowed values are: all, indicating that a user selecting a suggestion is selecting all of the actions within it; any, indicating that the end user may choose any number of actions including none of them or all of them; at-most-one, indicating that the user may choose none or at most one of the actions. If not provided, the default is all. Note: this is an STU element."
 * cards.suggestions.actionSelectionBehavior ^defaultValueCode = #all

--- a/input/fsh/logicals/CDSHooksResponse.fsh
+++ b/input/fsh/logicals/CDSHooksResponse.fsh
@@ -28,7 +28,7 @@ Description: "This structure is defined to allow the FHIR Validator to validate 
 * cards.source.topic 0..1 Coding "Describes the content of the card" "A topic describes the content of the card by providing a high-level categorization that can be useful for filtering, searching or ordered display of related cards in the CDS client's UI. This specification does not prescribe a standard set of topics"
 * cards.source.topic ^comment = "This specification does not prescribe a standard set of topics"
 * cards.suggestions 0..* http://hl7.org/fhir/tools/StructureDefinition/CDSHooksElement "Suggest a set of changes in the context of the current activity" "Allows a service to suggest a set of changes in the context of the current activity (e.g. changing the dose of a medication currently being prescribed, for the order-sign activity)."
-* cards.suggestions obeys cds-resp-5
+* cards.suggestions obeys cds-resp-5 and cds-resp-7
 * cards.suggestions ^condition[0] = "cds-resp-1"
 * cards.suggestions ^condition[+] = "cds-resp-6"
 * cards.suggestions.label 1..1 string "Human-readable label to display for this suggestion" "Human-readable label to display for this suggestion"
@@ -49,6 +49,8 @@ Description: "This structure is defined to allow the FHIR Validator to validate 
 * cards.suggestions.actions.resource ^comment = "Use of this field to communicate a string of a FHIR id for delete suggestions is DEPRECATED and resourceId SHOULD be used instead."
 * cards.suggestions.actions.resourceId 0..1 url "A relative reference to the relevant resource." "A relative reference to the relevant resource. SHOULD be provided when the type attribute is delete."
 * cards.suggestions.actions.resourceId ^comment = ""
+* cards.suggestions.actionSelectionBehavior 0..1 code "all | any | at-most-one (default: all)" "Indicates whether the end user may select any, none, or only a single action from those included in the suggestion. Allowed values are: all, indicating that a user selecting a suggestion is selecting all of the actions within it; any, indicating that the end user may choose any number of actions including none of them or all of them; at-most-one, indicating that the user may choose none or at most one of the actions. If not provided, the default is all. Note: this is an STU element."
+* cards.suggestions.actionSelectionBehavior ^defaultValueCode = #all
 * cards.selectionBehavior 0..1 code "at-most-one | any" "Describes the intended selection behavior of the suggestions in the card. Allowed values are: at-most-one, indicating that the user may choose none or at most one of the suggestions; any, indicating that the end user may choose any number of suggestions including none of them and all of them"
 * cards.selectionBehavior from http://hl7.org/fhir/tools/ValueSet/CDSSelectionBehavior (required)
 * cards.selectionBehavior ^comment = "CDS Clients that do not understand the value MUST treat the card as an error."


### PR DESCRIPTION
  Reconciles the logical model profiles in `input/fsh/logicals/` with the narrative tables in `input/pagecontent/index.md`, and fills a gap where the Feedback request body had no validatable model.

  - **Add `cards.suggestions.actionSelectionBehavior`** to `CDSHooksResponse` with default `all` and a new `cds-resp-7` invariant constraining the value to `all | any | at-most-one`. Matches the field documented at `index.md:892` that was missing from the logical model.                                                                                                               
  - **Change `CDSHooksRequest.hook` type** from `code` to `string`, matching `CDSHooksServices.services.hook` and the narrative tables at `index.md:119` and `index.md:190`.                                                                                              
  - **Change `cards.suggestions.actions.resourceId` type** from `url` to `string`. The narrative describes this as a relative         
  reference (e.g. `ServiceRequest/procedure-request-1`); `url` implies an absolute URI.                                      
  - **Add `CDSHooksFeedback` logical model** covering the feedback POST body, accepted-suggestion entries, and override-reason  structure documented at `index.md:1106-1236`. Includes three new invariants:
    - `cds-fb-1` — `outcome` must be `accepted` or `overridden`                                                                       
    - `cds-fb-2` — `outcome = 'accepted'` requires `acceptedSuggestions`
    - `cds-fb-3` — an `overrideReason` must contain `reason`, `userComment`, or both  