### PR TITLE
FHIR-53840: Note that examples use FHIR R4 unless otherwise noted

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -41,6 +41,8 @@ Well-tuned implementations improve patient safety and clinician efficiency; poor
 
 See [https://cds-hooks.org/](https://cds-hooks.org/) for additional information, resources and ways to get involved.
 
+Unless otherwise noted, all examples that make use of FHIR resources are for [FHIR R4](https://hl7.org/fhir/R4/).
+
 ### Conformance Language
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this specification are to be interpreted as described in [RFC2119](https://tools.ietf.org/html/rfc2119). Further, the key word "CONDITIONAL" indicates that a particular item is either REQUIRED or OPTIONAL, based upon another item.
 


### PR DESCRIPTION
Add general language to the Overview stating that, unless otherwise noted, all examples using FHIR resources are FHIR R4. Verified there are no non-R4 FHIR examples in the spec. 

Per FHIR-53840 resolution (non-substantive).