### PR TITLE
FHIR-54815: typo & Clarify embedded FHIR uses standard FHIR JSON seri…

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -46,7 +46,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Use of JSON
 
-All data exchanged through production RESTful APIs SHALL be sent and received as [JSON](https://tools.ietf.org/html/rfc8259) (JavaScript Object Notation) and structures and are transmitted over HTTPS. See [Security and Safety](#security-and-safety) section. All embedded FHIR resources SHALL be sent and recieved as [fhir+json](https://hl7.org/fhir/R4/json.html). 
+All data exchanged through production RESTful APIs SHALL be sent and received as [JSON](https://tools.ietf.org/html/rfc8259) (JavaScript Object Notation) structures and are transmitted over HTTPS. See [Security and Safety](#security-and-safety) section. All embedded FHIR resources SHALL use the standard [FHIR JSON serialization](https://hl7.org/fhir/R4/json.html) (`fhir+json`). 
 
 JSON comments and trailing commas SHOULD NOT be transmitted as they are not part of the JSON specification.
 


### PR DESCRIPTION
…alization

Note that this is effectively a technical correction. Fix typo, slight non-substantive wording change to existing requirement to adhere more closely with resolution of FHIR-54815.

Update the Use of JSON section to clarify that all embedded FHIR resources use the standard FHIR JSON serialization (fhir+json), linked to the FHIR json.html page. Also fixes minor grammar and a typo.

Per FHIR-54815 resolution (non-substantive). https://jira.hl7.org/browse/FHIR-54815