### PR TITLE
FHIR-54673: Add hookVersion to discovery response; version uses semver

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -35,6 +35,7 @@ Note: The contents of this section are Standard for Trial Use (STU)
 * Recommend CDS Clients to [use a JSON Web Key Set Url and rotate keys](index.html#trusting-cds-clients) ([FHIR-41437](https://jira.hl7.org/browse/FHIR-41437), [FHIR-28695](https://jira.hl7.org/browse/FHIR-28695))
 * Recommend CDS Services [advertise their version of CDS Hooks](index.html#response) ([FHIR-28650](https://jira.hl7.org/browse/FHIR-28650))
 * [Require CDS Clients to document support](index.html#capability-documentation) of `suggestion.actionSelectionBehavior` ([FHIR-28684](https://jira.hl7.org/browse/FHIR-28684))
+* Add [`hookVersion` to the discovery response](index.html#response) and express the service's CDS Hooks `version` using semantic versioning ([FHIR-54673](https://jira.hl7.org/browse/FHIR-54673))
 
 **Clarifications and Documentation Improvements:**
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -124,7 +124,8 @@ Field | Optionality | Type | Description
 `id` | REQUIRED | *string* | The {id} portion of the URL to this service which is available at<br />`{baseUrl}/cds-services/{id}`
 `prefetch` | OPTIONAL | *object* | An object containing key/value pairs of FHIR queries that this service is requesting the CDS Client to perform and provide on each service call. The key is a *string* that describes the type of data being requested and the value is a *string* representing the FHIR query.<br />See [Prefetch Template](#prefetch-template).
 `usageRequirements`| OPTIONAL | *string* | Human-friendly description of any preconditions for the use of this CDS Service.
-`version`| RECOMMENDED | *string* | The version of the CDS Hooks specification implemented (STU1 \| STU2 \| STU3).
+`version`| RECOMMENDED | *string* | The [semantic version](https://semver.org/) of the CDS Hooks specification implemented by this service (e.g. `3.0.0`).
+`hookVersion`| OPTIONAL | *string* | The version of the hook this service supports, which SHALL match the [`hookVersion`](#hook-version) in the published hook definition. A service that supports multiple versions of the same hook exposes each version at a separate endpoint.
 {:.grid}
 
 Note that a CDS server can host multiple entries of CDS service with the same `id` for different `hook`s. This allows a service to update its advice based on changes in workflow as discussed in [*update stale guidance*](#update-stale-guidance).


### PR DESCRIPTION
Add a hookVersion element to the CDS Services discovery response so aservice can indicate which hook version it supports (matching the hook definition's hookVersion); multiple hook versions are exposed at separate endpoints. Update the version element to use the semantic version of the CDS Hooks specification rather than STU1/STU2/STU3.

https://jira.hl7.org/browse/FHIR-54673