### PR TITLE
FHIR-54292: Clarify override reasons are suggested categories

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -952,10 +952,13 @@ The following example illustrates a delete action:
 
 **overrideReasons** is an array of **[Coding](#coding)** that captures a codified set of reasons an end user may select from as the rejection reason when rejecting the advice presented in the card. When using the coding object to represent a reason, CDS Services MUST provide a human readable text in the *display* property and CDS Clients MAY incorporate it into their user interface.
 
-Note: The contents of this section are Standard for Trial Use (STU). We seek feedback on these override reasons with the intent to allow implementations to align on standardized override reasons.
+Note: The contents of this section are Standard for Trial Use (STU). We seek feedback on these override reasons with the intent to allow implementations to align on standardized override reason categories.
 {:.stu-note}
 
-Although this specification is not prescriptive about the set of override reasons, a suggested set of standardized non-adherence reasons is provided in the [Non-Adherence Reason Codes](CodeSystem-non-adherence-reason-codes.html) code system. In addition, a suggested set of [clinically relevant codes](ValueSet-non-adherence-reason-clinical.html) is provided as a starting point for service providers to use.
+Override reasons are widely tailored per integration to match the clinical context and workflow. This specification is not prescriptive about the set of override reasons.
+{:.stu}
+
+Standardized non-adherence reasons could enable cross-organization analytics including downstream quality improvement. A suggested set of categories is provided in the [Non-Adherence Reason Codes](CodeSystem-non-adherence-reason-codes.html) code system. In addition, a suggested set of [clinically relevant codes](ValueSet-non-adherence-reason-clinical.html) is provided as a starting point for service providers to use.
 {:.stu}
 
 ```json


### PR DESCRIPTION
Expand the Trial-Use override reasons section to clarify that the provided value set is a set of logical categories that may not suit every clinical context, why standardized override reasons are not required, and the potential value (cross-organization analytics and quality improvement) of aligning on standardized categories. Per FHIR-54292 resolution (non-substantive).

https://jira.hl7.org/browse/FHIR-54292